### PR TITLE
Fixed constructor issue

### DIFF
--- a/contracts/misc/Migrations.sol
+++ b/contracts/misc/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
Sorry, i had an issue with the commit's user, so i closed my first MR and create a new one with the right user.

Previous description :

I was doing the getting started and I found this issue :

`Warning:` Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead. function Migrations() { ^ (Relevant source part starts here and spans across multiple `lines).`

Thanks by advance